### PR TITLE
Install from `requirements[-dev].txt` in GitHub Action

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -17,11 +17,8 @@ jobs:
           fetch-depth: 1
       - name: Install Dependencies
         run: |
-          pip install matplotlib
-          pip install treon
-          pip install pandas
-          pip install qiskit
-          pip install git+https://github.com/calebj15/qiskit-machine-learning.git@qka-runtime#egg=qiskit-machine-learning
+          pip install -r requirements-dev.txt -r requirements.txt
+          pip freeze
         shell: bash
       - name: Run Makefile
         env:


### PR DESCRIPTION
I think it makes sense to install directly from the requirements files
in CI/CD, to make sure they do not go out of date.

I've also added a `pip freeze` command so we can easily see
which package versions were used for a given CI run.