### PR TITLE
Fix cron syntax in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 0 2 1/1 * ? *'
+    - cron: '0 2 * * *'
 
 jobs:
   test_linux:


### PR DESCRIPTION
CI has been broken since 7a2485eb5850a77343329bd744c7aba8b8fedccd, with the error:

```
Invalid workflow file: .github/workflows/tests.yml#L1
invalid `cron` attribute "0 0 2 1/1 * ? *"
```

This fixes the syntax of the cron attribute.