### PR TITLE
Move ipywidgets to rquirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 nbmake>=1.3.3
 black[jupyter]==22.3.0
-ipywidgets>=7.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=1.3.4
 qiskit-aer>=0.12.0
 qiskit-terra>=0.24.0
 qiskit-machine-learning>=0.5.0
+ipywidgets>=7.7.1


### PR DESCRIPTION
This repo is centered around its notebooks, so they should all run with a base installation of the `requirements.txt`.

Several notebooks currently break in that environment due to a lack of ipywidgets package.

This PR moves ipywidgets from `requirements-dev.txt` to `requirements.txt`