### PR TITLE
Make the "latest version tests" fail upon any warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           make lint
       - name: Notebook Tests
         run: |
-          make test
+          make test PYTEST_FLAGS="-Werror"
   test_macOS:
     runs-on: macOS-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+PYTEST_FLAGS =
+
 .PHONY: lint test
 
 lint:
 	black --check docs
 
 test:
-	pytest --nbmake "docs/"
+	pytest --nbmake $(PYTEST_FLAGS) "docs/"


### PR DESCRIPTION
I was hoping to make the latest version tests fail if they emit any warning (particularly a deprecation warning).  However, it looks like nbmake currently does not support this, so the flag has no effect: https://github.com/treebeardtech/nbmake/issues/104